### PR TITLE
Add UI behavior and components.

### DIFF
--- a/flow-typed/sojourn.js
+++ b/flow-typed/sojourn.js
@@ -1,0 +1,17 @@
+
+declare type Action = { +type: string }
+declare type ModalState = { +show: boolean }
+declare type DrawerState = { +show: boolean }
+declare type MenuState = { +show: boolean }
+
+declare type UiState = {
+  +drawer: DrawerState,
+  +menu: MenuState,
+  +modal: ModalState,
+}
+
+declare type State = {
+  +ui: UiState
+}
+
+declare type HasChildren = { children?: any }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,0 +1,17 @@
+// @flow
+
+export const Empty: 'Empty' = 'Empty'
+export const ShowDrawer: 'ShowDrawer' = 'ShowDrawer'
+export const HideDrawer: 'HideDrawer' = 'HideDrawer'
+export const ShowMenu: 'ShowMenu' = 'ShowMenu'
+export const HideMenu: 'HideMenu' = 'HideMenu'
+export const ShowModal: 'ShowModal' = 'ShowModal'
+export const HideModal: 'HideModal' = 'HideModal'
+
+export const emptyAction = (): Action => ({ type: Empty })
+export const showDrawer = (): Action => ({ type: ShowDrawer })
+export const hideDrawer = (): Action => ({ type: HideDrawer })
+export const showMenu = (): Action => ({ type: ShowMenu })
+export const hideMenu = (): Action => ({ type: HideMenu })
+export const showModal = (): Action => ({ type: ShowModal })
+export const hideModal = (): Action => ({ type: HideModal })

--- a/src/components/App/Content/index.js
+++ b/src/components/App/Content/index.js
@@ -1,0 +1,9 @@
+// @flow
+
+import React from 'react'
+import { Container } from './styles'
+
+const Content = ({ children }: HasChildren) =>
+  <Container>{ children }</Container>
+
+export default Content

--- a/src/components/App/Content/styles.js
+++ b/src/components/App/Content/styles.js
@@ -1,0 +1,9 @@
+// @flow
+
+import styled from 'styled-components'
+import * as Theme from 'themes'
+
+export const Container = styled.header`
+  background: ${Theme.background};
+  color: ${Theme.foreground};
+`

--- a/src/components/App/Glance/index.js
+++ b/src/components/App/Glance/index.js
@@ -1,0 +1,9 @@
+// @flow
+
+import React from 'react'
+import { Container } from './styles'
+
+const Glance = ({ children }: HasChildren) =>
+  <Container>{ children }</Container>
+
+export default Glance

--- a/src/components/App/Glance/styles.js
+++ b/src/components/App/Glance/styles.js
@@ -1,0 +1,8 @@
+// @flow
+
+import styled from 'styled-components'
+import * as Theme from 'themes'
+
+export const Container = styled.header`
+  background: ${Theme.background};
+`

--- a/src/components/App/Letterhead/index.js
+++ b/src/components/App/Letterhead/index.js
@@ -1,0 +1,9 @@
+// @flow
+
+import React from 'react'
+import { Container } from './styles'
+
+const Letterhead = ({ children }: HasChildren) =>
+  <Container>{ children }</Container>
+
+export default Letterhead

--- a/src/components/App/Letterhead/styles.js
+++ b/src/components/App/Letterhead/styles.js
@@ -1,0 +1,8 @@
+// @flow
+
+import styled from 'styled-components'
+import * as Theme from 'themes'
+
+export const Container = styled.header`
+  background: ${Theme.background};
+`

--- a/src/components/App/Provider/createReducers.js
+++ b/src/components/App/Provider/createReducers.js
@@ -1,7 +1,11 @@
 // @flow
 
 import { combineReducers } from 'redux'
+import modal from 'reducers/modal'
+import menu from 'reducers/menu'
+import drawer from 'reducers/drawer'
 
-const ui = (state = {}, action) => state
-
-export default () => combineReducers({ ui })
+export default () =>
+  combineReducers({
+    ui: combineReducers({ drawer, menu, modal })
+  })

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -1,38 +1,15 @@
 // @flow
 
 import React from 'react'
-import chroma from 'chroma-js'
-import styled from 'styled-components'
 import Shell from './Shell'
+import Content from './Content'
+import Letterhead from './Letterhead'
+import Glance from './Glance'
 import Menu from 'components/Menu'
 import Drawer from 'components/Drawer'
 import Modal from 'components/Modal'
 
-const paper = chroma('cornsilk').desaturate(0.3).brighten(0.3).css()
-
-const Layout = styled.div`
-  display: grid;
-  grid-template-columns: 100%;
-  grid-template-rows: 2fr 20fr 1fr;
-
-  position: relative;
-  height: 100vh;
-  width: 100vw;
-  z-index: 1;
-`
-
-const Content = styled.main`
-  background: ${paper};
-  color: midnightblue;
-`
-
-const Letterhead = styled.header`
-  background: ${paper};
-`
-
-const Glance = styled.footer`
-  background: ${paper};
-`
+import { Layout } from './styles'
 
 const App = (props: any): React$Element<any> =>
   <Shell>

--- a/src/components/App/styles.js
+++ b/src/components/App/styles.js
@@ -1,0 +1,15 @@
+// @flow
+
+import styled from 'styled-components'
+import * as Theme from 'themes'
+
+export const Layout = styled.div`
+  display: grid;
+  grid-template-columns: 100%;
+  grid-template-rows: 2fr 20fr 1fr;
+
+  position: relative;
+  height: 100%;
+  width: 100%;
+  z-index: 1;
+`

--- a/src/components/Drawer/index.js
+++ b/src/components/Drawer/index.js
@@ -1,37 +1,10 @@
 // @flow
 
-import React from 'react'
-import chroma from 'chroma-js'
-import styled from 'styled-components'
+import { connect } from 'react-redux'
+import View from './view'
 
-type DrawerProps = { children?: any }
+const mapStateToProps = (state: State): MenuState => (
+  { show: state.ui.drawer.show }
+)
 
-const paper = chroma('cornsilk').desaturate(0.3).brighten(0.3).css()
-const Backdrop = styled.div`
-  background: rgba(0, 0, 0, 0.4);
-
-  display: flex;
-  justify-content:flex-end;
-  align-items: center;
-  align-content: center;
-
-  position: absolute;
-  width: 100vw;
-  height: 100vh;
-  z-index: 2;
-`
-
-const Container = styled.div`
-  width: 30vw;
-  height: 100vh;
-  background: ${paper};
-`
-
-const Drawer = ({ children }: DrawerProps) =>
-  <Backdrop>
-    <Container>
-      { children }
-    </Container>
-  </Backdrop>
-
-export default Drawer
+export default connect(mapStateToProps)(View)

--- a/src/components/Drawer/styles.js
+++ b/src/components/Drawer/styles.js
@@ -1,0 +1,44 @@
+// @flow
+
+import styled from 'styled-components'
+import * as Theme from 'themes'
+
+const slideLeft = ({ show }) =>
+  show
+    ? 'translate3d(0, 0, 0)'
+    : 'translate3d(100vw, 0, 0)'
+
+const fadeIn = ({ show }) =>
+  show
+    ? Theme.shadow
+    : Theme.transparent
+
+export const Backdrop = styled.div`
+  background: ${fadeIn};
+
+  display: flex;
+  justify-content:flex-end;
+  align-items: center;
+  align-content: center;
+
+  overflow: hidden;
+  position: absolute;
+  width: 100vw;
+  height: 100vh;
+  z-index: 2;
+
+  pointer-events: none;
+  transition: ${Theme.transition};
+  transition-delay: ${Theme.transition};
+`
+
+export const Container = styled.div`
+  background: ${Theme.background};
+  box-shadow: 0 0 24px -4px ${Theme.foreground};
+
+  width: 30vw;
+  height: 100vh;
+
+  transition: ${Theme.transition};
+  transform: ${slideLeft}
+`

--- a/src/components/Drawer/view.js
+++ b/src/components/Drawer/view.js
@@ -1,0 +1,13 @@
+// @flow
+
+import React from 'react'
+import { Backdrop, Container } from './styles'
+
+const Drawer = ({ children, show }: HasChildren & DrawerState) =>
+  <Backdrop show={ show }>
+    <Container show={ show }>
+      { children }
+    </Container>
+  </Backdrop>
+
+export default Drawer

--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -1,37 +1,10 @@
 // @flow
 
-import React from 'react'
-import chroma from 'chroma-js'
-import styled from 'styled-components'
+import { connect } from 'react-redux'
+import View from './view'
 
-type MenuProps = { children?: any }
+const mapStateToProps = (state: State): MenuState => (
+  { show: state.ui.menu.show }
+)
 
-const paper = chroma('cornsilk').desaturate(0.3).brighten(0.3).css()
-const Backdrop = styled.div`
-  background: rgba(0, 0, 0, 0.4);
-
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-  align-content: center;
-
-  position: absolute;
-  width: 100vw;
-  height: 100vh;
-  z-index: 3;
-`
-
-const Container = styled.div`
-  width: 30vw;
-  height: 100vh;
-  background: ${paper};
-`
-
-const Menu = ({ children }: MenuProps) =>
-  <Backdrop>
-    <Container>
-      { children }
-    </Container>
-  </Backdrop>
-
-export default Menu
+export default connect(mapStateToProps)(View)

--- a/src/components/Menu/styles.js
+++ b/src/components/Menu/styles.js
@@ -1,0 +1,44 @@
+// @flow
+
+import styled from 'styled-components'
+import * as Theme from 'themes'
+
+const slideRight = ({ show }) =>
+  show
+    ? 'translate3d(0, 0, 0)'
+    : 'translate3d(-100vw, 0, 0)'
+
+const fadeIn = ({ show }) =>
+  show
+    ? Theme.shadow
+    : Theme.transparent
+
+export const Backdrop = styled.div`
+  background: ${fadeIn};
+
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  align-content: center;
+
+  overflow: hidden;
+  position: absolute;
+  width: 100vw;
+  height: 100vh;
+  z-index: 3;
+
+  pointer-events: none;
+  transition: ${Theme.transition};
+  transition-delay: ${Theme.transition};
+`
+
+export const Container = styled.div`
+  background: ${Theme.background};
+  box-shadow: 0 0 24px -4px ${Theme.foreground};
+
+  width: 30vw;
+  height: 100vh;
+
+  transition: ${Theme.transition};
+  transform: ${slideRight}
+`

--- a/src/components/Menu/view.js
+++ b/src/components/Menu/view.js
@@ -1,0 +1,13 @@
+// @flow
+
+import React from 'react'
+import { Backdrop, Container } from './styles'
+
+const Menu = ({ children, show }: HasChildren & MenuState) =>
+  <Backdrop show={ show }>
+    <Container show={ show }>
+      { children }
+    </Container>
+  </Backdrop>
+
+export default Menu

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -1,38 +1,10 @@
 // @flow
 
-import React from 'react'
-import chroma from 'chroma-js'
-import styled from 'styled-components'
+import { connect } from 'react-redux'
+import View from './view'
 
-type ModalProps = { children?: any }
+const mapStateToProps = (state: State): ModalState => (
+  { show: state.ui.modal.show }
+)
 
-const paper = chroma('cornsilk').desaturate(0.3).brighten(0.3).css()
-const Backdrop = styled.div`
-  background: rgba(0, 0, 0, 0.4);
-
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  align-content: center;
-
-  position: absolute;
-  width: 100vw;
-  height: 100vh;
-  z-index: 4;
-`
-
-const Container = styled.div`
-  width: 40vw;
-  min-height: 20vh;
-  background: ${paper};
-
-`
-
-const Modal = ({ children }: ModalProps) =>
-  <Backdrop>
-    <Container>
-      { children }
-    </Container>
-  </Backdrop>
-
-export default Modal
+export default connect(mapStateToProps)(View)

--- a/src/components/Modal/styles.js
+++ b/src/components/Modal/styles.js
@@ -1,0 +1,46 @@
+// @flow
+
+import styled from 'styled-components'
+import * as Theme from 'themes'
+
+const slideUp = ({ show }) =>
+  show
+    ? 'translate3d(0, 0, 0)'
+    : 'translate3d(0, 100vh, 0)'
+
+const fadeIn = ({ show }) =>
+  show
+    ? Theme.shadow
+    : Theme.transparent
+
+export const Backdrop = styled.div`
+  background: ${fadeIn};
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  align-content: center;
+
+  overflow: hidden;
+  position: absolute;
+  width: 100vw;
+  height: 100vh;
+  z-index: 4;
+
+  pointer-events: none;
+  transition: ${Theme.transition};
+  transition-delay: ${Theme.transition};
+`
+
+export const Container = styled.div`
+  background: ${Theme.background};
+  box-shadow: 0 0 24px -4px ${Theme.foreground};
+  border-radius: ${Theme.borderRadius};
+
+  width: 40vw;
+  min-height: 20vh;
+  max-height: 80vh;
+
+  transition: ${Theme.transition};
+  transform: ${slideUp}
+`

--- a/src/components/Modal/view.js
+++ b/src/components/Modal/view.js
@@ -1,0 +1,13 @@
+// @flow
+
+import React from 'react'
+import { Backdrop, Container } from './styles'
+
+const Modal = ({ children, show }: HasChildren & ModalState) =>
+  <Backdrop show={ show }>
+    <Container show={ show }>
+      { children }
+    </Container>
+  </Backdrop>
+
+export default Modal

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,10 @@
+* { box-sizing: border-box; }
+
 html, body {
   margin: 0;
   padding: 0;
-  height: 100vh;
-  width: 100vw;
+  height: 100%;
+  width: 100%;
 
   font-family: sans-serif;
 

--- a/src/reducers/drawer.js
+++ b/src/reducers/drawer.js
@@ -1,0 +1,21 @@
+// @flow
+
+import * as Actions from 'actions'
+
+const defaults: DrawerState = { show: false }
+
+const drawer = (
+  state: DrawerState = defaults,
+  action: Action
+): DrawerState => {
+  switch (action.type) {
+    case Actions.HideDrawer:
+      return { ...state, show: false }
+    case Actions.ShowDrawer:
+      return { ...state, show: true }
+    default:
+      return { ...state }
+  }
+}
+
+export default drawer

--- a/src/reducers/drawer.test.js
+++ b/src/reducers/drawer.test.js
@@ -1,0 +1,26 @@
+// @flow
+
+import { expect } from 'chai'
+import drawer from './drawer'
+import * as Actions from 'actions'
+
+describe("drawer", () => {
+  it("doesn't show by default", () => {
+    const state = drawer(undefined, Actions.emptyAction())
+
+    expect(state.show).to.be.false
+  })
+
+  it("can be told to show", () => {
+    const state = drawer(undefined, Actions.showDrawer())
+
+    expect(state.show).to.be.true
+  })
+
+  it("can be told to hide", () => {
+    const init = drawer(undefined, Actions.showDrawer())
+    const state = drawer(init, Actions.hideDrawer())
+
+    expect(state.show).to.be.false
+  })
+})

--- a/src/reducers/menu.js
+++ b/src/reducers/menu.js
@@ -1,0 +1,21 @@
+// @flow
+
+import * as Actions from 'actions'
+
+const defaults: MenuState = { show: false }
+
+const menu = (
+  state: MenuState = defaults,
+  action: Action
+): MenuState => {
+  switch (action.type) {
+    case Actions.HideMenu:
+      return { ...state, show: false }
+    case Actions.ShowMenu:
+      return { ...state, show: true }
+    default:
+      return { ...state }
+  }
+}
+
+export default menu

--- a/src/reducers/menu.test.js
+++ b/src/reducers/menu.test.js
@@ -1,0 +1,26 @@
+// @flow
+
+import { expect } from 'chai'
+import menu from './menu'
+import * as Actions from 'actions'
+
+describe("menu", () => {
+  it("doesn't show by default", () => {
+    const state = menu(undefined, Actions.emptyAction())
+
+    expect(state.show).to.be.false
+  })
+
+  it("can be told to show", () => {
+    const state = menu(undefined, Actions.showMenu())
+
+    expect(state.show).to.be.true
+  })
+
+  it("can be told to hide", () => {
+    const init = menu(undefined, Actions.showMenu())
+    const state = menu(init, Actions.hideMenu())
+
+    expect(state.show).to.be.false
+  })
+})

--- a/src/reducers/modal.js
+++ b/src/reducers/modal.js
@@ -1,0 +1,18 @@
+// @flow
+
+import * as Actions from 'actions'
+
+const defaults: ModalState = { show: false }
+
+const modal = (state: ModalState = defaults, action: Action): ModalState => {
+  switch (action.type) {
+    case Actions.HideModal:
+      return { ...state, show: false }
+    case Actions.ShowModal:
+      return { ...state, show: true }
+    default:
+      return { ...state }
+  }
+}
+
+export default modal

--- a/src/reducers/modal.test.js
+++ b/src/reducers/modal.test.js
@@ -1,0 +1,26 @@
+// @flow
+
+import { expect } from 'chai'
+import modal from './modal'
+import * as Actions from 'actions'
+
+describe("modal", () => {
+  it("doesn't show by default", () => {
+    const state = modal(undefined, Actions.emptyAction())
+
+    expect(state.show).to.be.false
+  })
+
+  it("can be told to show", () => {
+    const state = modal(undefined, Actions.showModal())
+
+    expect(state.show).to.be.true
+  })
+
+  it("can be told to hide", () => {
+    const init = modal(undefined, Actions.showModal())
+    const state = modal(init, Actions.hideModal())
+
+    expect(state.show).to.be.false
+  })
+})

--- a/src/themes/index.js
+++ b/src/themes/index.js
@@ -1,0 +1,13 @@
+// @flow
+
+import chroma from 'chroma-js'
+
+export const borderRadius = '3px'
+export const transition = "0.3s"
+export const transparent = 'rgba(0, 0, 0, 0)'
+export const shadow = 'rgba(0, 0, 0, 0.4)'
+export const foreground = 'midnightblue'
+export const background = chroma('cornsilk')
+  .desaturate(0.3)
+  .brighten(0.3)
+  .css()


### PR DESCRIPTION
This commit introduces some essential chrome to the App, and is probably
the last pre-logic setup commit.

The three new components are:

* `<Modal />`
* `<Drawer />`
* `<Menu />`

And they serve more or less as visually significant ways to offer
different types of interactions to a user.  They each accept children
and a visibility toggle, and they're each wired into the `ui` slice of
the redux state tree.

Two questions stick out in my head:

* There's a lot of repetition in the styles.  How can I reduce this in a
  way which is still pleasant to maintain going forward?
* Should the Modal / Drawer / Menu elements be put into the App purview?
  Is App really a marriage of Bootstrapping + Chrome?