### PR TITLE
Create Note core domain.

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,5 +7,6 @@
 [libs]
 
 [options]
+unsafe.enable_getters_and_setters=true
 module.system.node.resolve_dirname=node_modules
 module.system.node.resolve_dirname=src

--- a/flow-typed/sojourn.js
+++ b/flow-typed/sojourn.js
@@ -1,3 +1,9 @@
+declare type Parse = string => string
+declare type Content = string
+declare type Id = string
+declare type Title = string
+
+declare interface Note { +id: Id, +title: Title, +content: Content }
 
 declare type Action = { +type: string }
 declare type ModalState = { +show: boolean }
@@ -10,8 +16,13 @@ declare type UiState = {
   +modal: ModalState,
 }
 
-declare type State = {
-  +ui: UiState
-}
-
+declare type State = { +ui: UiState }
 declare type HasChildren = { children?: any }
+
+declare interface Storage {
+  get(key: string): any,
+  all(): Array<any>,
+  put(key: Id, value: any): void,
+  remove(key: string): void,
+  flush(): void
+}

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
   "dependencies": {
     "animated": "^0.2.0",
     "chroma-js": "^1.3.4",
+    "dompurify": "^0.9.0",
     "font-awesome": "^4.7.0",
     "history": "^4.5.1",
+    "markdown": "^0.5.0",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-redux": "^5.0.5",

--- a/src/components/App/Drawer/styles.js
+++ b/src/components/App/Drawer/styles.js
@@ -15,7 +15,7 @@ export const Backdrop = BaseBackdrop.extend`
 
 export const Container = styled.div`
   background: ${Theme.background};
-  box-shadow: 0 0 24px -4px ${Theme.foreground};
+  box-shadow: ${Theme.boxShadow};
 
   width: 30vw;
   height: 100vh;

--- a/src/components/App/Menu/styles.js
+++ b/src/components/App/Menu/styles.js
@@ -15,7 +15,7 @@ export const Backdrop = BaseBackdrop.extend`
 
 export const Container = styled.div`
   background: ${Theme.background};
-  box-shadow: 0 0 24px -4px ${Theme.foreground};
+  box-shadow: ${Theme.boxShadow};
 
   width: 30vw;
   height: 100vh;

--- a/src/components/App/Modal/styles.js
+++ b/src/components/App/Modal/styles.js
@@ -15,7 +15,7 @@ export const Backdrop = BaseBackdrop.extend`
 
 export const Container = styled.div`
   background: ${Theme.background};
-  box-shadow: 0 0 24px -4px ${Theme.foreground};
+  box-shadow: ${Theme.boxShadow};
   border-radius: ${Theme.borderRadius};
 
   width: 40vw;

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -12,11 +12,15 @@ import Shell from './Shell'
 
 import { Layout } from './styles'
 
+import Editor from 'components/Editor'
+
 const App = (props: any): React$Element<any> =>
   <Shell>
     <Layout>
       <Letterhead />
-      <Content />
+      <Content>
+        <Editor />
+      </Content>
       <Glance />
       <Menu />
       <Drawer />

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -1,0 +1,7 @@
+import React from 'react'
+import { Container } from './styles'
+
+const Editor = ({ children }: HasChildren) =>
+  <Container>{ children }</Container>
+
+export default Editor

--- a/src/components/Editor/styles.js
+++ b/src/components/Editor/styles.js
@@ -1,0 +1,10 @@
+// @flow
+
+import styled from 'styled-components'
+import * as Theme from 'themes'
+
+export const Container = styled.section`
+  box-shadow: ${Theme.boxShadow};
+  margin: 2em;
+  padding: 2em;
+`

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,0 +1,8 @@
+import Notes from "./notes"
+import Store from "./store"
+import * as Parser from './parser'
+
+export { Notes, Store, Parser }
+
+export default class Core {
+}

--- a/src/core/index.spec.js
+++ b/src/core/index.spec.js
@@ -1,0 +1,14 @@
+// @flow
+
+import { expect } from "chai"
+import Core, * as CoreLibs from "./index"
+
+describe("Core", () => {
+  it("is exported", () => { expect(Core).to.be.ok })
+
+  describe("Libs", () => {
+    it("exports Notes", () => { expect(CoreLibs.Notes).to.be.ok })
+    it("exports Store", () => { expect(CoreLibs.Store).to.be.ok })
+    it("exports Parser", () => { expect(CoreLibs.Parser).to.be.ok })
+  })
+})

--- a/src/core/notes/entity/index.js
+++ b/src/core/notes/entity/index.js
@@ -1,0 +1,26 @@
+// @flow
+
+import * as uuid from "uuid"
+import * as NoteValidations from "../validations"
+
+export default class NoteEntity implements Note {
+  attributes: Note
+
+  defaults: Note = {
+    id: uuid.v4(),
+    title: "",
+    content: ""
+  }
+
+  constructor(attributes: Note = this.defaults) {
+    this.attributes = { ...this.defaults, ...attributes }
+  }
+
+  get content(): Content { return this.attributes.content }
+  get id(): Id { return this.attributes.id }
+  get title(): Title { return this.attributes.title }
+
+  isEmpty(): boolean {
+    return NoteValidations.isEmpty(this)
+  }
+}

--- a/src/core/notes/entity/index.spec.js
+++ b/src/core/notes/entity/index.spec.js
@@ -1,0 +1,21 @@
+// @flow
+
+import { expect } from "chai"
+import NoteEntity from "./index"
+
+describe("NoteEntity", () => {
+  const id = "some-id-string"
+  const title = "An Article"
+  const content = "# Hello!"
+  const entity = new NoteEntity({ id, title, content })
+
+  it("has an id", () => { expect(entity.id).to.eql(id) })
+  it("has a title", () => { expect(entity.title).to.eql(title) })
+  it("has content", () => { expect(entity.content).to.eql(content) })
+
+  describe("#isEmpty", () => {
+    it("is empty when brand new", () => {
+      expect(new NoteEntity().isEmpty()).to.be.true
+    })
+  })
+})

--- a/src/core/notes/index.js
+++ b/src/core/notes/index.js
@@ -1,0 +1,64 @@
+// @flow
+
+import events from "events"
+import Store from "core/store"
+import NoteEntity from "./entity"
+
+const { EventEmitter } = events
+
+export const NOTES_GET = "notes.get"
+export const NOTES_FIND = "notes.find"
+export const NOTES_CREATE = "notes.create"
+export const NOTES_UPDATE = "notes.update"
+export const NOTES_REMOVE = "notes.remove"
+
+export default class Articles {
+  events: EventEmitter = new EventEmitter()
+  store: Storage
+
+  constructor(store: Storage) {
+    this.store = store
+  }
+
+  async create(note: NoteEntity): Promise<NoteEntity> {
+    await this.store.put(note.id, note)
+
+    this.events.emit(NOTES_CREATE, note)
+
+    return await this.store.get(note.id)
+  }
+
+  async find(): Promise<Array<NoteEntity>> {
+    const notes: Array<NoteEntity> = await this.store.all()
+    this.events.emit(NOTES_FIND, notes)
+    return notes
+  }
+
+  async get(id: string): Promise<NoteEntity> {
+    const note: NoteEntity = await this.store.get(id)
+    this.events.emit(NOTES_GET, note)
+    return note
+  }
+
+  async init(): Promise<NoteEntity> {
+    return new NoteEntity()
+  }
+
+  on(channel: string, listener: Function) {
+    this.events.on(channel, listener)
+  }
+
+  async remove(note: NoteEntity): Promise<void> {
+    await this.store.remove(note.id)
+    this.events.emit(NOTES_REMOVE, note)
+  }
+
+  async update(note: NoteEntity): Promise<NoteEntity> {
+    await this.store.put(note.id, note)
+
+    this.events.emit(NOTES_UPDATE, note)
+
+    return await this.store.get(note.id)
+  }
+
+}

--- a/src/core/notes/index.spec.js
+++ b/src/core/notes/index.spec.js
@@ -1,0 +1,148 @@
+import { expect } from "chai"
+import Store from "../../core/store"
+import Notes, * as NotesEvents from "./index"
+import NoteEntity from "./entity"
+
+describe("Notes", () => {
+  const store = new Store.Memory()
+  const notes = new Notes(store)
+
+  afterEach(() => store.flush())
+
+  it("exists", () => { expect(Notes).to.be.ok })
+
+  describe("#create", () => {
+    const note = new NoteEntity()
+
+    it("emits NOTES_SAVE, with note to listeners", () => {
+      let saveContents: NoteEntity | null = null
+
+      notes.on(
+        NotesEvents.NOTES_CREATE,
+        (note: NoteEntity) => saveContents = note
+      )
+
+      return notes
+        .create(note)
+        .then(() => expect(saveContents).to.eql(note))
+    })
+
+    it("promises a returned note", () => {
+      return notes
+        .create(note)
+        .then((subject) => expect(subject).to.eql(note))
+    })
+  })
+
+  describe("#index", () => {
+    const note = new NoteEntity()
+
+    it("emits NOTES_INDEX with note to listeners", () => {
+      let getResults: NoteEntity[] | null = null
+
+      notes.on(
+        NotesEvents.NOTES_FIND,
+        (results: NoteEntity[]) => getResults = results
+      )
+
+      return notes
+        .create(note)
+        .then(() => notes.find())
+        .then(() => expect(getResults).to.eql([note]))
+    })
+
+    it("promises a returned notes list", () => {
+      return notes
+        .create(note)
+        .then(() => notes.find())
+        .then((subject) => expect(subject).to.eql([note]))
+    })
+  })
+
+  describe("#get", () => {
+    const note = new NoteEntity()
+
+    it("emits NOTES_FIND with note to listeners", () => {
+      let getResult: NoteEntity | null = null
+
+      notes.on(
+        NotesEvents.NOTES_GET,
+        (note: NoteEntity) => getResult = note
+      )
+
+      return notes
+        .create(note)
+        .then(() => notes.get(note.id))
+        .then(() => expect(getResult).to.eql(note))
+    })
+
+    it("promises a returned note", () => {
+      return notes
+        .create(note)
+        .then(() => notes.get(note.id))
+        .then((subject) => expect(subject).to.eql(note))
+    })
+  })
+
+  describe("#init", () => {
+    it("promises a new note", () => {
+      return notes
+        .init()
+        .then((subject) => expect(subject.isEmpty()).to.be.true)
+    })
+  })
+
+  describe("#update", () => {
+    const note = new NoteEntity()
+
+    it("emits NOTES_UPDATE, with note to listeners", () => {
+      let updateContents: NoteEntity | null = null
+
+      notes.on(
+        NotesEvents.NOTES_UPDATE,
+        (note: NoteEntity) => updateContents = note
+      )
+
+      return notes
+        .create(note)
+        .then(() => notes.update(note))
+        .then(() => expect(updateContents).to.eql(note))
+    })
+
+    it("promises the updated note", () => {
+      return notes
+        .create(note)
+        .then(() => notes.update(note))
+        .then((subject) => expect(subject).to.eql(note))
+    })
+  })
+
+  describe("#remove", () => {
+    const note = new NoteEntity()
+
+    it("emits NOTES_REMOVE", () => {
+      let wasCalled: boolean = false
+
+      notes.on(NotesEvents.NOTES_REMOVE, () => wasCalled = true)
+
+      return notes
+        .remove(note)
+        .then(() => expect(wasCalled).to.be.true)
+    })
+
+    it("removes the note", () => {
+      return notes
+        .create(note)
+        .then((note) => expect(note).to.eql(note))
+        .then(() => notes.remove(note) )
+        .then((subject) => expect(subject).to.be.undefined)
+    })
+
+    it("returns an empty promise", () => {
+      return notes
+        .remove(note)
+        .then((subject) => expect(subject).to.be.undefined)
+    })
+  })
+
+})

--- a/src/core/notes/validations/index.js
+++ b/src/core/notes/validations/index.js
@@ -1,0 +1,12 @@
+// @flow
+
+import NoteEntity from "core/notes/entity"
+
+export const noContent = (note: Note): boolean =>
+  note.content === undefined || note.content.length === 0
+
+export const noTitle = (note: Note): boolean =>
+  note.title === undefined || note.title.length === 0
+
+export const isEmpty = (note: Note): boolean =>
+  noTitle(note) && noContent(note)

--- a/src/core/notes/validations/index.spec.js
+++ b/src/core/notes/validations/index.spec.js
@@ -1,0 +1,62 @@
+import { expect } from "chai"
+import NoteEntity from "../entity"
+import * as NoteValidations from "./index"
+
+describe("Note validations", () => {
+
+  describe("#noContent", () => {
+    describe("with no content", () => {
+      it("is true", () => {
+        const note: NoteEntity = new NoteEntity()
+        expect(NoteValidations.noContent(note)).to.be.true
+      })
+    })
+
+    describe("otherwise", () => {
+      it("is false", () => {
+        const note: NoteEntity = new NoteEntity({ content: "# Hi! " })
+        expect(NoteValidations.noContent(note)).to.be.false
+      })
+    })
+  })
+
+  describe("#noTitle", () => {
+    describe("with no title", () => {
+      it("is true", () => {
+        const note: NoteEntity = new NoteEntity()
+        expect(NoteValidations.noTitle(note)).to.be.true
+      })
+    })
+
+    describe("otherwise", () => {
+      it("is false", () => {
+        const note: NoteEntity = new NoteEntity({ title: "Greetings" })
+        expect(NoteValidations.noTitle(note)).to.be.false
+      })
+    })
+  })
+
+  describe("#isEmpty", () => {
+    describe("with no title and body", () => {
+      it("is true", () => {
+        const note: NoteEntity = new NoteEntity()
+        expect(NoteValidations.isEmpty(note)).to.be.true
+      })
+    })
+
+    describe("with content", () => {
+      it("is false", () => {
+        const note: NoteEntity = new NoteEntity({ content: "# Hi! " })
+        expect(NoteValidations.isEmpty(note)).to.be.false
+      })
+    })
+
+    describe("with a title", () => {
+      it("is false", () => {
+        const note: NoteEntity = new NoteEntity({ title: "Greetings" })
+        expect(NoteValidations.isEmpty(note)).to.be.false
+      })
+    })
+  })
+
+})

--- a/src/core/parser/index.js
+++ b/src/core/parser/index.js
@@ -1,0 +1,12 @@
+// @flow
+
+import { markdown } from "markdown"
+import { sanitize as domSanitizer } from "dompurify"
+
+const sanitize =
+  process.env.NODE_ENV === 'test'
+    ? string => string
+    : domSanitizer
+
+export const parse: Parser = content =>
+  sanitize(markdown.toHTML(content))

--- a/src/core/parser/index.test.js
+++ b/src/core/parser/index.test.js
@@ -1,0 +1,10 @@
+// @flow
+
+import { expect } from 'chai'
+import * as notes from './index'
+
+describe("parsing markdown", () => {
+  it("converts to HTML", () => {
+    expect(notes.parse('# hey')).to.eql('<h1>hey</h1>')
+  })
+})

--- a/src/core/store/index.js
+++ b/src/core/store/index.js
@@ -1,0 +1,7 @@
+// @flow
+
+import Memory from "./memory"
+
+const strategies = { Memory }
+
+export default strategies

--- a/src/core/store/index.spec.js
+++ b/src/core/store/index.spec.js
@@ -1,0 +1,8 @@
+// @flow
+
+import { expect } from "chai"
+import Store from "./index"
+
+describe("Store", () => {
+  it("exposes Memory", () => { expect(Store.Memory).to.be.ok })
+})

--- a/src/core/store/memory/index.js
+++ b/src/core/store/memory/index.js
@@ -1,0 +1,27 @@
+// @flow
+
+import Store from "core/store"
+
+const memory: any = {}
+
+export default class Memory implements Storage {
+  all(): Array<any> {
+    return Object.keys(memory).map(key => memory[key])
+  }
+
+  get(key: string): any {
+    return memory[key]
+  }
+
+  flush(): void {
+    Object.keys(memory).map(key => this.remove(key))
+  }
+
+  put(key: string, value: any): void {
+    memory[key] = value
+  }
+
+  remove(key: string): void {
+    delete memory[key]
+  }
+}

--- a/src/core/store/memory/index.spec.js
+++ b/src/core/store/memory/index.spec.js
@@ -1,0 +1,49 @@
+// @flow
+
+import { expect } from "chai"
+import Memory from "./index"
+
+describe("Memory", () => {
+  const store = new Memory()
+
+  describe("#all", () => {
+    it("returns all inserted items", () => {
+      const value = "hey"
+      store.put("anything", value)
+      expect(store.all()).to.eql([value])
+    })
+  })
+
+  describe("#get", () => {
+    it("returns null if it doesn't have a value", () => {
+      expect(store.get("nothing")).to.be.undefined
+    })
+  })
+
+  describe("#put", () => {
+    it("puts the given item in the given key", () => {
+      const key = "some-id-probably"
+      const value = {}
+
+      store.put(key, value)
+
+      expect(store.get(key)).to.eql(value)
+    })
+  })
+
+  describe("remove", () => {
+    it("removes the given key", () => {
+      const key = "some-id-probably"
+      const value = "Hooray!"
+
+      store.put(key, value)
+
+      expect(store.get(key)).to.eql(value)
+
+      store.remove(key)
+
+      expect(store.get(key)).to.be.undefined
+    })
+
+  })
+})

--- a/src/themes/index.js
+++ b/src/themes/index.js
@@ -11,3 +11,6 @@ export const background = chroma('cornsilk')
   .desaturate(0.3)
   .brighten(0.3)
   .css()
+
+export const shade = chroma(foreground).alpha(0.8).css()
+export const boxShadow = `0 0 24px -4px ${shade}`

--- a/yarn.lock
+++ b/yarn.lock
@@ -2029,6 +2029,10 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
+dompurify@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-0.9.0.tgz#470f9dd95657a644a84be1ed950677946259d055"
+
 domutils@1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.1.6.tgz#bddc3de099b9a2efacc51c623f28f416ecc57485"
@@ -4174,6 +4178,12 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
+markdown@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/markdown/-/markdown-0.5.0.tgz#28205b565a8ae7592de207463d6637dc182722b2"
+  dependencies:
+    nopt "~2.1.1"
+
 "match-stream@>= 0.0.2 < 1":
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/match-stream/-/match-stream-0.0.2.tgz#99eb050093b34dffade421b9ac0b410a9cfa17cf"
@@ -4443,6 +4453,12 @@ nopt@^4.0.1:
   dependencies:
     abbrev "1"
     osenv "^0.1.4"
+
+nopt@~2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-2.1.2.tgz#6cccd977b80132a07731d6e8ce58c2c8303cf9af"
+  dependencies:
+    abbrev "1"
 
 normalize-css-color@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This commit introduces the note core domain and prepares to use it in
tandem with Draft.js (through the Editor component).

To explain myself, the Editor component came first and it was pretty
nice (to a certain degree). Then I'd realized I was spiking things out
while reading the Draft js docs.  Not good.

So, in comes the Core domain.  This domain is ported from a previous
work (see esmevane/journaling for more) where I was more back-end
focused.  But, that back end architecture is important here, because in
the land of React / Redux, you are constantly coerced into a
component-centric design.

Here's the point:

From here on out, most features will be implemented through this core
domain, and exposed through some sort of boundary built deliberately on
top of that.  Then Redux will provide that behavior to the component
layer.

For example, persistence (thinking of GunDB here) will be a Storage
strategy implemented through Core Storage.

As another example, Draft JS will be integrated first with Core
(possibly through a new bounded context) and then after that's done,
that context (not Draft JS itself) will be integrated with the Editor.